### PR TITLE
perf(cache): coalesce epoch bumps so a bench batch is one invalidation

### DIFF
--- a/site/migrations/0020_epoch_debounce.sql
+++ b/site/migrations/0020_epoch_debounce.sql
@@ -1,0 +1,32 @@
+-- 0020_epoch_debounce.sql
+-- Coalesce epoch bumps so a bench batch causes a handful of cache
+-- invalidations instead of one per write.
+--
+-- The epoch scheme (0016) was built on the assumption that publishes are rare.
+-- They are not, during an active bench run: every run ingest and every finalize
+-- bumped the epoch, and each bump invalidates every cached aggregate in every
+-- colo at once. Measured 2026-09-07: the epoch had reached 559, up from 4 on
+-- 2026-09-02 — 555 global invalidations in five days, roughly 111/day. Reads
+-- tracked it exactly:
+--
+--     Sep 7 07:00     12,470 read   1,331 written   ingest burst
+--     Sep 7 08:00    666,097 read      33 written   re-warm
+--     Sep 7 09:00    742,572 read      18 written   re-warm
+--
+-- 90.9% of the daily cap, while quiet hours stayed at 6-45 rows. The caching
+-- was working; it was being torn down a hundred times a day. Mode-scoped keys
+-- (0019) multiply the keyspace, so each teardown now costs more than it did.
+--
+-- New model: writes MARK the cache dirty rather than incrementing. A reader
+-- promotes the pending mark to a real bump once the debounce window has passed.
+-- That bounds invalidations to one per window while still guaranteeing every
+-- write becomes visible, without needing a scheduler.
+--
+--   pending_since  unix ms of the FIRST write since the last bump; 0 = clean.
+--                  Kept as the first rather than the latest write so the
+--                  window measures how long data has been stale, not how
+--                  recently it changed — otherwise a steady write stream would
+--                  postpone the bump forever.
+--   last_bump_at   unix ms of the last promotion, for observability.
+ALTER TABLE cache_epoch ADD COLUMN pending_since INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE cache_epoch ADD COLUMN last_bump_at INTEGER NOT NULL DEFAULT 0;

--- a/site/scripts/bump-epoch.ts
+++ b/site/scripts/bump-epoch.ts
@@ -33,7 +33,13 @@ function d1(sql: string, extra = ""): string {
 }
 
 console.log(`Bumping data epoch (${local ? "local" : "remote"})...`);
-d1("UPDATE cache_epoch SET epoch = epoch + 1 WHERE id = 1");
+// Force path: clears any pending mark too, so this means "visible now"
+// rather than "data changed". Ordinary writes go through the debounce
+// in src/lib/server/data-epoch.ts.
+d1(
+  "UPDATE cache_epoch SET epoch = epoch + 1, pending_since = 0, "
+    + "last_bump_at = CAST(strftime('%s','now') AS INTEGER) * 1000 WHERE id = 1",
+);
 const out = d1("SELECT epoch FROM cache_epoch WHERE id = 1", "--json");
 const epoch = JSON.parse(out.slice(out.indexOf("[")))[0].results[0].epoch;
 console.log(

--- a/site/src/lib/server/data-epoch.ts
+++ b/site/src/lib/server/data-epoch.ts
@@ -70,16 +70,62 @@ export const EPOCH_KEYED_TTL_SECONDS = 86_400;
 export const DEGRADED_TTL_SECONDS = 60;
 
 /**
- * Reads the current data epoch. Never throws: on any failure (including a DB
- * that predates migration 0016, where `.first()` returns null) it returns a
- * time-bucket token so the caller degrades to 60s-TTL behaviour.
+ * How long a write may stay invisible before a reader promotes it.
+ *
+ * Sized against what it is coalescing: a bench batch writes continuously for
+ * minutes, so anything in the tens of seconds collapses it to a handful of
+ * invalidations. 60s is the largest value that still reads as "immediately"
+ * for someone who has just published and gone to look.
+ */
+const DEBOUNCE_MS = 60_000;
+
+/**
+ * Reads the current data epoch, promoting a pending write if the debounce
+ * window has passed.
+ *
+ * Writes no longer increment the epoch themselves (see BUMP_DATA_EPOCH_SQL);
+ * they only mark it dirty. Promotion happens here, on the read path, because
+ * that is the only place guaranteed to run again after the window elapses —
+ * a scheduler would be the alternative and the nightly cron is far too coarse.
+ *
+ * The promotion is a compare-and-set on the exact `pending_since` value that
+ * was read, so concurrent readers across colos produce at most one increment
+ * per window: the first CAS wins, the rest match zero rows and fall through.
+ * Either way the caller gets `epoch + 1`, which is correct for both the winner
+ * and the losers — nothing can have bumped twice inside one window.
+ *
+ * Never throws: on any failure (including a DB predating migration 0016, where
+ * `.first()` returns null) it returns a time-bucket token and the caller
+ * degrades to 60s-TTL behaviour.
  */
 export async function readDataEpoch(db: D1Database): Promise<EpochToken> {
   try {
     const row = await db
-      .prepare(`SELECT epoch FROM cache_epoch WHERE id = 1`)
-      .first<{ epoch: number }>();
-    if (row && Number.isFinite(row.epoch)) return `e${row.epoch}`;
+      .prepare(`SELECT epoch, pending_since FROM cache_epoch WHERE id = 1`)
+      .first<{ epoch: number; pending_since: number }>();
+    if (!row || !Number.isFinite(row.epoch)) return fallbackToken();
+
+    const pending = Number(row.pending_since ?? 0);
+    const due = pending !== 0 && Date.now() - pending >= DEBOUNCE_MS;
+    if (!due) return `e${row.epoch}`;
+
+    // Promotion is best-effort: if it fails we simply serve the current epoch
+    // and the next reader tries again. A failed promotion must never fail a
+    // request, and cannot lose the write — `pending_since` stays set.
+    try {
+      await db
+        .prepare(
+          `UPDATE cache_epoch
+              SET epoch = epoch + 1, pending_since = 0, last_bump_at = ?
+            WHERE id = 1 AND pending_since = ?`,
+        )
+        .bind(Date.now(), pending)
+        .run();
+    } catch (err) {
+      console.error("[data-epoch] promotion failed:", err);
+      return `e${row.epoch}`;
+    }
+    return `e${row.epoch + 1}`;
   } catch (err) {
     console.error("[data-epoch] read failed, falling back to time bucket:", err);
   }
@@ -105,8 +151,26 @@ export function isFallbackEpoch(token: EpochToken): boolean {
  * fails leaves every colo serving stale data for the full 24h TTL — precisely
  * the failure this design exists to prevent.
  */
+/**
+ * Marks the cache dirty. Despite the name this no longer increments anything —
+ * `readDataEpoch` promotes the mark once DEBOUNCE_MS has passed. The name and
+ * signature are kept so the eleven write sites that splice this into their
+ * batches need no change.
+ *
+ * `pending_since` is only set when currently zero, so it records the FIRST
+ * write since the last bump. Taking the latest write instead would let a steady
+ * stream of writes push the deadline out indefinitely and never promote.
+ *
+ * It MUST still go inside the same batch as the write it accompanies. Outside
+ * the batch a committed write can pair with a failed mark, leaving every colo
+ * serving stale data until something else writes.
+ */
 export const BUMP_DATA_EPOCH_SQL =
-  `UPDATE cache_epoch SET epoch = epoch + 1 WHERE id = 1`;
+  `UPDATE cache_epoch
+      SET pending_since = CASE WHEN pending_since = 0
+                               THEN CAST(strftime('%s','now') AS INTEGER) * 1000
+                               ELSE pending_since END
+    WHERE id = 1`;
 
 export function bumpDataEpochStmt(db: D1Database): D1PreparedStatement {
   return db.prepare(BUMP_DATA_EPOCH_SQL);
@@ -145,4 +209,22 @@ export function buildCacheKey(
   u.searchParams.set("_cv", CACHE_VERSION);
   u.searchParams.set("_de", epoch);
   return new Request(u.toString(), { method: "GET" });
+}
+
+/**
+ * Bumps immediately, skipping the debounce.
+ *
+ * For the operator script and any caller that means "make this visible now"
+ * rather than "data changed". Ordinary write paths should use
+ * `bumpDataEpochStmt` so bench batches stay coalesced.
+ */
+export async function forceBumpDataEpoch(db: D1Database): Promise<void> {
+  await db
+    .prepare(
+      `UPDATE cache_epoch
+          SET epoch = epoch + 1, pending_since = 0, last_bump_at = ?
+        WHERE id = 1`,
+    )
+    .bind(Date.now())
+    .run();
 }

--- a/site/tests/api/data-epoch.test.ts
+++ b/site/tests/api/data-epoch.test.ts
@@ -49,8 +49,17 @@ async function epochState(): Promise<{ epoch: number; pending: number }> {
  * neither leaves pending at 0 and the epoch unmoved, and still fails here.
  */
 async function expectBump(label: string, fn: () => Promise<void>) {
+  // Clear any mark left by fixture setup — the finalize case has to ingest a
+  // run first, and that ingest legitimately marks the cache. Clearing here
+  // rather than demanding the fixture start clean keeps the assertion measuring
+  // only what `fn` did, while still refusing to pass on a pre-existing mark.
+  await env.DB
+    .prepare(`UPDATE cache_epoch SET pending_since = 0 WHERE id = 1`)
+    .run();
+
   const before = await epochState();
-  expect(before.pending, `${label}: fixture must start unmarked`).toBe(0);
+  expect(before.pending, `${label}: mark must be cleared before the action`)
+    .toBe(0);
   await fn();
   const after = await epochState();
   const invalidated = after.pending !== 0 || after.epoch > before.epoch;

--- a/site/tests/api/data-epoch.test.ts
+++ b/site/tests/api/data-epoch.test.ts
@@ -24,24 +24,42 @@ beforeEach(async () => {
   await seedMinimalRefData();
 });
 
-async function epoch(): Promise<number> {
+async function epochState(): Promise<{ epoch: number; pending: number }> {
   const row = await env.DB.prepare(
-    `SELECT epoch FROM cache_epoch WHERE id = 1`,
-  ).first<{ epoch: number }>();
-  return row!.epoch;
+    `SELECT epoch, pending_since FROM cache_epoch WHERE id = 1`,
+  ).first<{ epoch: number; pending_since: number }>();
+  return { epoch: row!.epoch, pending: Number(row!.pending_since) };
 }
 
 /**
- * Asserts that `fn` moves the data epoch. This is deliberately an integration
- * assertion against real D1 rather than a lint that the route imports the bump
- * helper: importing it and forgetting the statement, or calling it outside the
- * batch, both pass an import check and both reintroduce the stale-cache bug.
+ * Asserts that `fn` invalidates the cache.
+ *
+ * Since migration 0020 a write no longer increments the epoch directly — it
+ * MARKS the cache dirty and a reader promotes the mark once the debounce
+ * window passes (see src/lib/server/data-epoch.ts). So the contract a write
+ * path must satisfy is "the cache will be invalidated", which is satisfied by
+ * either outcome: a pending mark, or an increment if the window had already
+ * elapsed. Asserting only the increment is what made these four tests fail
+ * when the debounce landed.
+ *
+ * What must NOT weaken is the reason this is an integration assertion against
+ * real D1 rather than a lint that the route imports the helper: importing it
+ * and forgetting the statement, or calling it outside the batch, both pass an
+ * import check and both reintroduce the stale-cache bug. A route that does
+ * neither leaves pending at 0 and the epoch unmoved, and still fails here.
  */
 async function expectBump(label: string, fn: () => Promise<void>) {
-  const before = await epoch();
+  const before = await epochState();
+  expect(before.pending, `${label}: fixture must start unmarked`).toBe(0);
   await fn();
-  const after = await epoch();
-  expect(after, `${label} must bump the data epoch`).toBeGreaterThan(before);
+  const after = await epochState();
+  const invalidated = after.pending !== 0 || after.epoch > before.epoch;
+  expect(
+    invalidated,
+    `${label} must invalidate the cache (mark it pending, or bump if the ` +
+      `debounce window had elapsed); saw epoch ${before.epoch}->${after.epoch}, ` +
+      `pending ${before.pending}->${after.pending}`,
+  ).toBe(true);
 }
 
 describe("cache key normalization", () => {

--- a/site/tests/api/epoch-debounce.test.ts
+++ b/site/tests/api/epoch-debounce.test.ts
@@ -34,11 +34,19 @@ beforeEach(async () => {
   await resetDb();
 });
 
-async function state(): Promise<{ epoch: number; pending_since: number }> {
+async function state(): Promise<
+  { epoch: number; pending_since: number; last_bump_at: number }
+> {
   const row = await env.DB
-    .prepare(`SELECT epoch, pending_since FROM cache_epoch WHERE id = 1`)
-    .first<{ epoch: number; pending_since: number }>();
-  return { epoch: row!.epoch, pending_since: Number(row!.pending_since) };
+    .prepare(
+      `SELECT epoch, pending_since, last_bump_at FROM cache_epoch WHERE id = 1`,
+    )
+    .first<{ epoch: number; pending_since: number; last_bump_at: number }>();
+  return {
+    epoch: row!.epoch,
+    pending_since: Number(row!.pending_since),
+    last_bump_at: Number(row!.last_bump_at),
+  };
 }
 
 /** Backdates the pending mark so the debounce window has provably elapsed. */
@@ -100,7 +108,8 @@ describe("a reader promotes once the window has passed", () => {
     const after = await state();
     expect(after.epoch).toBe(before.epoch + 1);
     expect(after.pending_since, "mark cleared on promotion").toBe(0);
-    expect(after.last_bump_at ?? 0).toBeGreaterThan(0);
+    expect(after.last_bump_at, "promotion records its time")
+      .toBeGreaterThan(0);
   });
 
   it("promotes exactly once even with concurrent readers", async () => {

--- a/site/tests/api/epoch-debounce.test.ts
+++ b/site/tests/api/epoch-debounce.test.ts
@@ -1,0 +1,174 @@
+import { applyD1Migrations, env } from "cloudflare:test";
+import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import {
+  bumpDataEpoch,
+  forceBumpDataEpoch,
+  readDataEpoch,
+} from "../../src/lib/server/data-epoch";
+import { resetDb } from "../utils/reset-db";
+
+/**
+ * Writes coalesce into at most one cache invalidation per debounce window.
+ *
+ * The epoch scheme assumed publishes were rare. During a bench run they are
+ * not: every run ingest and every finalize bumped the epoch, and each bump
+ * invalidates every cached aggregate in every colo. Measured 2026-09-07, the
+ * epoch had reached 559 from 4 five days earlier — 555 global invalidations,
+ * driving a day to 90.9% of the D1 read cap while quiet hours sat at 6-45 rows.
+ *
+ * The invariant these tests pin down is two-sided, and both halves matter:
+ *   - a burst of writes must NOT produce a burst of invalidations, and
+ *   - no write may be lost — every one becomes visible within the window.
+ *
+ * Time is driven by writing `pending_since` directly rather than by faking
+ * clocks, because the window is evaluated in SQL and in the worker isolate.
+ */
+
+const WINDOW_MS = 60_000;
+
+beforeAll(async () => {
+  await applyD1Migrations(env.DB, env.TEST_MIGRATIONS);
+});
+
+beforeEach(async () => {
+  await resetDb();
+});
+
+async function state(): Promise<{ epoch: number; pending_since: number }> {
+  const row = await env.DB
+    .prepare(`SELECT epoch, pending_since FROM cache_epoch WHERE id = 1`)
+    .first<{ epoch: number; pending_since: number }>();
+  return { epoch: row!.epoch, pending_since: Number(row!.pending_since) };
+}
+
+/** Backdates the pending mark so the debounce window has provably elapsed. */
+async function agePendingMark(byMs = WINDOW_MS + 1_000): Promise<void> {
+  await env.DB
+    .prepare(
+      `UPDATE cache_epoch SET pending_since = pending_since - ? WHERE id = 1`,
+    )
+    .bind(byMs)
+    .run();
+}
+
+describe("a write marks, it does not bump", () => {
+  it("leaves the epoch alone and records a pending mark", async () => {
+    const before = await state();
+    await bumpDataEpoch(env.DB);
+    const after = await state();
+
+    expect(after.epoch, "epoch must not move on the write itself").toBe(
+      before.epoch,
+    );
+    expect(after.pending_since, "write must record a pending mark")
+      .toBeGreaterThan(0);
+  });
+
+  it("keeps the FIRST mark, so a write stream cannot postpone promotion", async () => {
+    await bumpDataEpoch(env.DB);
+    const first = await state();
+    await bumpDataEpoch(env.DB);
+    await bumpDataEpoch(env.DB);
+    const later = await state();
+
+    // Taking the latest write instead would push the deadline out forever
+    // under continuous ingest, and the batch would never become visible.
+    expect(later.pending_since).toBe(first.pending_since);
+  });
+});
+
+describe("a reader promotes once the window has passed", () => {
+  it("does not promote inside the window", async () => {
+    const before = await state();
+    await bumpDataEpoch(env.DB);
+
+    const token = await readDataEpoch(env.DB);
+    expect(token, "still the old epoch inside the window").toBe(
+      `e${before.epoch}`,
+    );
+    expect((await state()).epoch).toBe(before.epoch);
+  });
+
+  it("promotes after the window and clears the mark", async () => {
+    const before = await state();
+    await bumpDataEpoch(env.DB);
+    await agePendingMark();
+
+    const token = await readDataEpoch(env.DB);
+    expect(token).toBe(`e${before.epoch + 1}`);
+
+    const after = await state();
+    expect(after.epoch).toBe(before.epoch + 1);
+    expect(after.pending_since, "mark cleared on promotion").toBe(0);
+    expect(after.last_bump_at ?? 0).toBeGreaterThan(0);
+  });
+
+  it("promotes exactly once even with concurrent readers", async () => {
+    const before = await state();
+    await bumpDataEpoch(env.DB);
+    await agePendingMark();
+
+    // The compare-and-set is on the exact pending_since read, so the first
+    // writer wins and the rest match zero rows.
+    const tokens = await Promise.all([
+      readDataEpoch(env.DB),
+      readDataEpoch(env.DB),
+      readDataEpoch(env.DB),
+      readDataEpoch(env.DB),
+    ]);
+
+    expect((await state()).epoch, "at most one bump per window").toBe(
+      before.epoch + 1,
+    );
+    // Every reader sees the promoted value, winner or not.
+    for (const t of tokens) expect(t).toBe(`e${before.epoch + 1}`);
+  });
+});
+
+describe("the coalescing actually coalesces", () => {
+  it("turns a burst of writes into a single invalidation", async () => {
+    const before = await state();
+
+    // Stand-in for a bench batch: many ingests inside one window.
+    for (let i = 0; i < 25; i++) await bumpDataEpoch(env.DB);
+    expect((await state()).epoch, "no bumps during the burst").toBe(
+      before.epoch,
+    );
+
+    await agePendingMark();
+    await readDataEpoch(env.DB);
+
+    // 25 writes, one invalidation. Before this change it was 25 — which is how
+    // the epoch reached 559 in five days.
+    expect((await state()).epoch).toBe(before.epoch + 1);
+  });
+
+  it("no write is lost: a later write still promotes", async () => {
+    const before = await state();
+    await bumpDataEpoch(env.DB);
+    await agePendingMark();
+    await readDataEpoch(env.DB); // promotes to +1, clears the mark
+
+    // A write after the promotion must start a fresh cycle, not be swallowed.
+    await bumpDataEpoch(env.DB);
+    expect((await state()).pending_since).toBeGreaterThan(0);
+    await agePendingMark();
+    await readDataEpoch(env.DB);
+
+    expect((await state()).epoch).toBe(before.epoch + 2);
+  });
+});
+
+describe("force bump bypasses the debounce", () => {
+  it("bumps immediately and clears any pending mark", async () => {
+    const before = await state();
+    await bumpDataEpoch(env.DB); // leaves a pending mark, inside the window
+    await forceBumpDataEpoch(env.DB);
+
+    const after = await state();
+    expect(after.epoch).toBe(before.epoch + 1);
+    expect(after.pending_since, "force clears the mark too").toBe(0);
+    // And a subsequent read must not double-bump on the cleared mark.
+    expect(await readDataEpoch(env.DB)).toBe(`e${before.epoch + 1}`);
+  });
+});

--- a/site/tests/utils/reset-db.ts
+++ b/site/tests/utils/reset-db.ts
@@ -62,7 +62,13 @@ export async function resetDb(): Promise<void> {
     // API route) mid-`it` and then re-fetches will read its own stale cache,
     // because a direct write bumps nothing. Seed before the first fetch, or
     // call bumpEpochForTest() after the direct write.
-    env.DB.prepare(`UPDATE cache_epoch SET epoch = epoch + 1 WHERE id = 1`),
+    // Also clears pending_since: writes now MARK rather than increment
+    // (migration 0020), so a mark left by one `it` block would make the
+    // next block's 'this write invalidated the cache' assertion pass
+    // vacuously.
+    env.DB.prepare(
+      `UPDATE cache_epoch SET epoch = epoch + 1, pending_since = 0 WHERE id = 1`,
+    ),
   ]);
 
   const blobs = await env.BLOBS.list();
@@ -115,6 +121,8 @@ export async function resetDb(): Promise<void> {
  * endpoint expecting to see the change.
  */
 export async function bumpEpochForTest(): Promise<void> {
-  await env.DB.prepare(`UPDATE cache_epoch SET epoch = epoch + 1 WHERE id = 1`)
+  await env.DB.prepare(
+    `UPDATE cache_epoch SET epoch = epoch + 1, pending_since = 0 WHERE id = 1`,
+  )
     .run();
 }


### PR DESCRIPTION
## What happened

The epoch scheme assumed publishes were rare. During a bench run they are not — every run ingest **and** every finalize bumped the epoch, and each bump invalidates every cached aggregate in every colo at once.

Measured 2026-09-07: the epoch had reached **559**, up from **4** on 2026-09-02. That is 555 global invalidations in five days, roughly 111/day. Reads track the writes exactly:

```
Sep 7 07:00     12,470 read   1,331 written   ← ingest burst
Sep 7 08:00    666,097 read      33 written   ← re-warm
Sep 7 09:00    742,572 read      18 written   ← re-warm
```

That day reached **90.9% of the 5M cap** while quiet hours stayed at 6–45 rows. The caching was working; it was being torn down a hundred times a day.

```
day          rowsRead   % of cap
2026-09-02  1,653,077     33.1%
2026-09-03  1,008,081     20.2%
2026-09-04    831,640     16.6%
2026-09-05    215,258      4.3%   ← zero writes
2026-09-06  1,420,657     28.4%   ← 583 written
2026-09-07  4,544,532     90.9%   ← 1,884 written
```

Five-day mean is 20.5% of cap. The one day with no writes was 4.3%. The correlation is the whole story. Mode-scoped keys (0019) enlarge the keyspace, so each teardown now costs more than it did.

## The change

Writes **mark** the cache dirty instead of incrementing. A reader promotes the mark to a real bump once the 60s debounce window has passed. That bounds invalidations to one per window while still guaranteeing every write becomes visible, and needs no scheduler — the read path is the only thing guaranteed to run again after the window elapses, and the nightly cron is far too coarse.

Promotion is a compare-and-set on the exact `pending_since` that was read, so concurrent readers across colos produce at most one increment per window: the first CAS wins, the rest match zero rows. Both winner and losers return `epoch + 1`, which is correct — nothing can bump twice inside one window.

`pending_since` records the **first** write since the last bump, not the latest. Taking the latest would let continuous ingest push the deadline out indefinitely and never promote at all.

## The trade

A publish is now visible within 60s rather than instantly. That is deliberate: 60s is the largest value that still reads as "immediately" to someone who has just published and gone to look, and it collapses a multi-minute bench batch into a handful of invalidations rather than hundreds.

`forceBumpDataEpoch` and `npm run bump-epoch` bypass the debounce for "make this visible now".

## Blast radius

All eleven write sites are untouched. `BUMP_DATA_EPOCH_SQL` keeps its name and shape — only its semantics change — so the batches it is spliced into need no edits.

Safe to deploy before the migration lands: without the `pending_since` column the SELECT throws, `readDataEpoch` returns a time-bucket token, and callers degrade to the old 60s-TTL behaviour rather than failing.

## Verification

`npm run check` passes with 0 errors locally.

The tests pin **both halves** of the invariant, since pinning only one would be worse than useless: a burst of 25 writes must produce exactly one invalidation, **and** no write may be lost — the mark survives, promotes, and a later write starts a fresh cycle.

The worker build and test suite are verified by this PR's CI run. The SvelteKit cloudflare adapter fails with EPERM on a git worktree on this machine, and the main checkout is in use by another session's bench work, so I could not run them locally.

https://claude.ai/code/session_01HVJuX6kfXhTPwASMVPAMPV